### PR TITLE
Fix broken spec to match behaviour

### DIFF
--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -46,7 +46,7 @@ module GraphiQL
         get :show, **graphql_params_with_theme
         assert_response(:success)
         assert_includes(@response.body, 'my/endpoint', 'it uses the provided path')
-        assert_match(/random_theme.css/, @response.body, 'it includes assets')
+        assert_includes(@response.body, 'class="random_theme"', 'it includes the color theme')
       end
 
       test 'it uses initial_query config' do


### PR DESCRIPTION
```
cdeliens in ~/development/graphiql-rails on CORE-9485 ● λ rake test
Run options: --seed 10474

# Running:

............

Finished in 0.072398s, 165.7504 runs/s, 593.9391 assertions/s.

12 runs, 43 assertions, 0 failures, 0 errors, 0 skips
```