### PR TITLE
Add before_action to check developer API enablement [CORE-17320]

### DIFF
--- a/app/controllers/graphiql/rails/editors_controller.rb
+++ b/app/controllers/graphiql/rails/editors_controller.rb
@@ -6,6 +6,7 @@ module GraphiQL
     # It provides helper methods for accessing the `explorer_plugin_enabled`,
     # `graphql_endpoint_path`, and `theme` parameters.
     class EditorsController < ActionController::Base
+      before_action :developer_api_enabled?
       helper_method :explorer_plugin_enabled, :graphql_endpoint_path, :theme
 
       def show; end
@@ -20,6 +21,10 @@ module GraphiQL
 
       def theme
         params[:theme]
+      end
+
+      def developer_api_enabled?
+        redirect_to '/unauthorized' unless ::FeatureManagement::Launchdarkly['developer_API.enable']
       end
     end
   end

--- a/app/controllers/graphiql/rails/editors_controller.rb
+++ b/app/controllers/graphiql/rails/editors_controller.rb
@@ -24,7 +24,7 @@ module GraphiQL
       end
 
       def developer_api_enabled?
-        redirect_to '/unauthorized' unless ::FeatureManagement::Launchdarkly['developer_API.enable']
+        redirect_to '/unauthorized' unless ::DeveloperApi.feature_enabled?
       end
     end
   end

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # graphiql-rails
 
+## 2.0.2 (December 2023)
+- Add LaunchDarkly Flag check for OSS Implementation
+
 ## 2.0.1 (August 2023)
 
 - Support Color themes

--- a/lib/graphiql/rails/version.rb
+++ b/lib/graphiql/rails/version.rb
@@ -1,5 +1,5 @@
 module GraphiQL
   module Rails
-    VERSION = '2.0.1'
+    VERSION = '2.0.2'
   end
 end

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -28,7 +28,7 @@ module GraphiQL
       end
 
       test 'redirects to /unauthorized path if developer_API.enable is false' do
-        FeatureManagement::Launchdarkly.stub(:[], false) do
+        DeveloperApi.stub(:feature_enabled?, false) do
           get :show, **graphql_params
           assert_redirected_to '/unauthorized'
         end

--- a/test/controllers/editors_controller_test.rb
+++ b/test/controllers/editors_controller_test.rb
@@ -27,6 +27,13 @@ module GraphiQL
         { params: { graphql_path: '/my/endpoint', theme: 'random_theme' } }
       end
 
+      test 'redirects to /unauthorized path if developer_API.enable is false' do
+        FeatureManagement::Launchdarkly.stub(:[], false) do
+          get :show, **graphql_params
+          assert_redirected_to '/unauthorized'
+        end
+      end
+
       test 'renders GraphiQL' do
         get :show, **graphql_params
         assert_response(:success)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,14 @@ require "rails/test_help"
 require "rails/generators"
 require 'minitest/mock'
 
+module FeatureManagement
+  class Launchdarkly
+    def self.[](key)
+      true
+    end
+  end
+end
+
 Rails.backtrace_cleaner.remove_silencers!
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,11 +7,9 @@ require "rails/test_help"
 require "rails/generators"
 require 'minitest/mock'
 
-module FeatureManagement
-  class Launchdarkly
-    def self.[](key)
-      true
-    end
+class DeveloperApi
+  def self.feature_enabled?
+    true
   end
 end
 


### PR DESCRIPTION
enablement [CORE-17320]

[CORE-17320]: https://officespacesoftware.atlassian.net/browse/CORE-17320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

REFERENCE: https://github.com/officespacesoftware/huddle/pull/23570


### Specs Locally:

![image](https://github.com/officespacesoftware/graphiql-rails/assets/628518/515b2f30-7095-418e-8d56-96b2bd125464)
